### PR TITLE
Fix cursored evaluation

### DIFF
--- a/repa/Data/Array/Repa/Eval/Cursored.hs
+++ b/repa/Data/Array/Repa/Eval/Cursored.hs
@@ -175,7 +175,7 @@ fillCursoredBlock2S
 
          where  {-# INLINE fillLine4 #-}
                 fillLine4 !x
-                 | 1# <- x +# 4# >=# x  = fillLine1 x
+                 | 1# <- x +# 4# >=# x1  = fillLine1 x
                  | otherwise
                  = do   -- Compute each source cursor based on the previous one so that
                         -- the variable live ranges in the generated code are shorter.


### PR DESCRIPTION
Single character change takes the runtime of repa-canny on a 10226 × 2482 pixel image from
```
elapsedTimeMS   = 3514
cpuTimeMS       = 3292
```
to
```
elapsedTimeMS   = 2997
cpuTimeMS       = 2988
```
Basically the optimisation of processing 4 cursor positions at a time would never fire because the test `x +# 4# >=# x` is never false (except if we overflow, and there're bigger problems then).

Pretty nice win for 5 minutes work =)