### PR TITLE
Support vector-0.12 and QuickCheck-2.10

### DIFF
--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -24,9 +24,9 @@ Library
         base                 >= 4.8 && < 4.10
       , template-haskell
       , ghc-prim
-      , vector               == 0.11.*
+      , vector               >= 0.11 && < 0.13
       , bytestring           == 0.10.*
-      , QuickCheck           >= 2.8 && < 2.10
+      , QuickCheck           >= 2.8 && < 2.11
 
   ghc-options:
         -Wall -fno-warn-missing-signatures


### PR DESCRIPTION
I tested that `repa` builds with `vector-0.12` and `QuickCheck-2.10`.

It would be great to get a Hackage release with this change because I just released [opencv](http://hackage.haskell.org/package/opencv) which depends on `repa` but it [fails to build](https://github.com/fpco/stackage/pull/2597) on Stackage because `repa` doesn't build with the latest `vector`.