### PR TITLE
Bump base bounds for REPA

### DIFF
--- a/repa-algorithms/repa-algorithms.cabal
+++ b/repa-algorithms/repa-algorithms.cabal
@@ -18,7 +18,7 @@ Synopsis:
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , vector               >= 0.11 && < 0.13
       , repa                 == 3.4.1.*
 

--- a/repa-examples/repa-examples.cabal
+++ b/repa-examples/repa-examples.cabal
@@ -25,7 +25,7 @@ Flag llvm
 
 Executable repa-canny
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
 
@@ -46,7 +46,7 @@ Executable repa-canny
 
 Executable repa-mmult
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , random               == 1.1.*
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
@@ -72,7 +72,7 @@ Executable repa-mmult
 
 Executable repa-laplace
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-io              == 3.4.1.*
       , template-haskell
@@ -95,7 +95,7 @@ Executable repa-laplace
 
 Executable repa-fft2d
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
       , repa-io              == 3.4.1.*
@@ -119,7 +119,7 @@ Executable repa-fft2d
 
 Executable repa-fft2d-highpass
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
       , repa-io              == 3.4.1.*
@@ -143,7 +143,7 @@ Executable repa-fft2d-highpass
 
 Executable repa-fft3d-highpass
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
 
@@ -166,7 +166,7 @@ Executable repa-fft3d-highpass
 
 Executable repa-blur
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
       , vector               >= 0.11 && < 0.13
@@ -190,7 +190,7 @@ Executable repa-blur
 
 Executable repa-sobel
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
 
@@ -214,7 +214,7 @@ Executable repa-sobel
 
 Executable repa-volume
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-io              == 3.4.1.*
 
@@ -236,7 +236,7 @@ Executable repa-volume
 
 Executable repa-unit-test
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , QuickCheck           >= 2.8 && < 2.14
 

--- a/repa-io/repa-io.cabal
+++ b/repa-io/repa-io.cabal
@@ -18,7 +18,7 @@ Synopsis:
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , binary               >= 0.7 && < 0.9
       , bmp                  == 1.2.*
       , bytestring           == 0.10.*

--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -21,7 +21,7 @@ Synopsis:
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , template-haskell
       , ghc-prim
       , vector               >= 0.11 && < 0.13


### PR DESCRIPTION
Bump base bounds for latest GHC.

This will allow me to prepare [perceptual-hash](http://hackage.haskell.org/package/perceptual-hash) for the release of GHC 8.8.1