### PR TITLE
Bump base bounds; add no-template-haskell flag to facilitate cross-compiling

### DIFF
--- a/repa-algorithms/repa-algorithms.cabal
+++ b/repa-algorithms/repa-algorithms.cabal
@@ -18,7 +18,7 @@ Synopsis:
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , vector               >= 0.11 && < 0.13
       , repa                 == 3.4.1.*
 

--- a/repa-examples/repa-examples.cabal
+++ b/repa-examples/repa-examples.cabal
@@ -25,7 +25,7 @@ Flag llvm
 
 Executable repa-canny
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
 
@@ -46,7 +46,7 @@ Executable repa-canny
 
 Executable repa-mmult
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , random               == 1.1.*
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
@@ -72,7 +72,7 @@ Executable repa-mmult
 
 Executable repa-laplace
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-io              == 3.4.1.*
       , template-haskell
@@ -95,7 +95,7 @@ Executable repa-laplace
 
 Executable repa-fft2d
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
       , repa-io              == 3.4.1.*
@@ -119,7 +119,7 @@ Executable repa-fft2d
 
 Executable repa-fft2d-highpass
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
       , repa-io              == 3.4.1.*
@@ -143,7 +143,7 @@ Executable repa-fft2d-highpass
 
 Executable repa-fft3d-highpass
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
 
@@ -166,7 +166,7 @@ Executable repa-fft3d-highpass
 
 Executable repa-blur
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
       , vector               >= 0.11 && < 0.13
@@ -190,7 +190,7 @@ Executable repa-blur
 
 Executable repa-sobel
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-algorithms      == 3.4.1.*
 
@@ -214,7 +214,7 @@ Executable repa-sobel
 
 Executable repa-volume
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , repa-io              == 3.4.1.*
 
@@ -236,7 +236,7 @@ Executable repa-volume
 
 Executable repa-unit-test
   Build-depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , repa                 == 3.4.1.*
       , QuickCheck           >= 2.8 && < 2.14
 

--- a/repa-io/repa-io.cabal
+++ b/repa-io/repa-io.cabal
@@ -18,7 +18,7 @@ Synopsis:
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , binary               >= 0.7 && < 0.9
       , bmp                  == 1.2.*
       , bytestring           == 0.10.*

--- a/repa/Data/Array/Repa/Stencil.hs
+++ b/repa/Data/Array/Repa/Stencil.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE    MagicHash, PatternGuards, BangPatterns, TemplateHaskell, QuasiQuotes,
-                ParallelListComp, TypeOperators, ExplicitForAll, ScopedTypeVariables #-}
 {-# OPTIONS -Wnot #-}
 
 -- | Efficient computation of stencil based convolutions.
@@ -14,6 +12,5 @@ where
 import Data.Array.Repa
 import Data.Array.Repa.Base
 import Data.Array.Repa.Stencil.Base
-import Data.Array.Repa.Stencil.Template
 import Data.Array.Repa.Specialised.Dim2
 

--- a/repa/Data/Array/Repa/Stencil/Dim2.hs
+++ b/repa/Data/Array/Repa/Stencil/Dim2.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE CPP, MagicHash #-}
 --   This is specialised for stencils up to 7x7.
 --   Due to limitations in the GHC optimiser, using larger stencils doesn't
 --   work, and will yield `error` at runtime. We can probably increase the
@@ -12,10 +12,12 @@
 --
 module Data.Array.Repa.Stencil.Dim2
         ( -- * Stencil creation
-          makeStencil2, stencil2
-
+          makeStencil2,
+#ifndef REPA_NO_TH
+          stencil2,
+#endif
           -- * Stencil operators
-        , PC5, mapStencil2, forStencil2)
+          PC5, mapStencil2, forStencil2)
 where
 import Data.Array.Repa.Base
 import Data.Array.Repa.Index
@@ -26,7 +28,9 @@ import Data.Array.Repa.Repr.Partitioned
 import Data.Array.Repa.Repr.HintSmall
 import Data.Array.Repa.Repr.Undefined
 import Data.Array.Repa.Stencil.Base
+#ifndef REPA_NO_TH
 import Data.Array.Repa.Stencil.Template
+#endif
 import Data.Array.Repa.Stencil.Partition
 import GHC.Exts
 

--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -21,7 +21,7 @@ Synopsis:
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.13
+        base                 >= 4.8 && < 4.14
       , template-haskell
       , ghc-prim
       , vector               >= 0.11 && < 0.13

--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -19,6 +19,10 @@ Description:
 Synopsis:
         High performance, regular, shape polymorphic parallel arrays.
 
+Flag no-template-haskell
+  Default: False
+  Description: Disable Template Haskell
+
 Library
   Build-Depends:
         base                 >= 4.8 && < 4.14
@@ -41,6 +45,9 @@ Library
   else
     ghc-options: -fcpr-off
 
+  if flag(no-template-haskell)
+    cpp-options: -DREPA_NO_TH
+
   extensions:
         NoMonomorphismRestriction
         ExplicitForAll
@@ -54,6 +61,13 @@ Library
         ScopedTypeVariables
         PatternGuards
         ExistentialQuantification
+
+  other-extensions:
+        CPP
+
+  if !flag(no-template-haskell)
+    other-extensions:
+        TemplateHaskell
 
   Exposed-modules:
         Data.Array.Repa.Eval.Gang
@@ -94,8 +108,11 @@ Library
         Data.Array.Repa.Eval.Reduction
         Data.Array.Repa.Eval.Selection
         Data.Array.Repa.Stencil.Base
-        Data.Array.Repa.Stencil.Template
         Data.Array.Repa.Stencil.Partition
         Data.Array.Repa.Base
+
+  if !flag(no-template-haskell)
+    Other-modules:
+        Data.Array.Repa.Stencil.Template
 
 -- vim: nospell


### PR DESCRIPTION
This bumps various bounds and adds a `no-template-haskell` flag to make cross-compiling repa feasible.