### PR TITLE
Build with `vector-0.13`

### DIFF
--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -28,7 +28,7 @@ Library
         base                 >= 4.8 && < 4.17
       , template-haskell
       , ghc-prim
-      , vector               >= 0.11 && < 0.13
+      , vector               >= 0.11 && < 0.14
       , bytestring           >= 0.10 && < 0.12
       , QuickCheck           >= 2.8  && < 2.15
 


### PR DESCRIPTION
Confirmed to build with `allow-newer: vector`.