### PR TITLE
updated base ceiling for repa

### DIFF
--- a/repa/repa.cabal
+++ b/repa/repa.cabal
@@ -25,7 +25,7 @@ Flag no-template-haskell
 
 Library
   Build-Depends:
-        base                 >= 4.8 && < 4.17
+        base                 >= 4.8 && < 5
       , template-haskell
       , ghc-prim
       , vector               >= 0.11 && < 0.13


### PR DESCRIPTION
Just a small change to the base ceiling version.

At the moment it prevents the installation of certain packages like [gloss-examples](https://hackage.haskell.org/package/gloss-examples).

`gloss-examples` installation output:

```
~/code/drakon # cabal install gloss-examples
Resolving dependencies...
Error: cabal: Could not resolve dependencies:
[__0] trying: gloss-examples-1.13.0.4 (user goal)
[__1] trying: repa-3.4.1.5 (dependency of gloss-examples)
[__2] next goal: containers (dependency of gloss-examples)
[__2] rejecting: containers-0.6.7/installed-0.6.7 (conflict: repa => base>=4.8
&& <4.17, containers => base==4.17.2.0/installed-4.17.2.0)
[__2] rejecting: containers-0.7 (conflict: gloss-examples => containers>=0.5
&& <0.7)
[__2] trying: containers-0.6.8
[__3] trying: gloss-1.13.2.2 (dependency of gloss-examples)
[__4] next goal: base (dependency of gloss-examples)
[__4] rejecting: base-4.17.2.0/installed-4.17.2.0 (conflict: repa => base>=4.8
&& <4.17)
[__4] skipping: base-4.19.0.0, base-4.18.2.0, base-4.18.1.0, base-4.18.0.0,
base-4.17.2.1, base-4.17.2.0, base-4.17.1.0, base-4.17.0.0 (has the same
characteristics that caused the previous version to fail: excluded by
constraint '>=4.8 && <4.17' from 'repa')
[__4] rejecting: base-4.16.4.0, base-4.16.3.0, base-4.16.2.0, base-4.16.1.0,
base-4.16.0.0, base-4.15.1.0, base-4.15.0.0, base-4.14.3.0, base-4.14.2.0,
base-4.14.1.0, base-4.14.0.0, base-4.13.0.0, base-4.12.0.0, base-4.11.1.0,
base-4.11.0.0, base-4.10.1.0, base-4.10.0.0, base-4.9.1.0, base-4.9.0.0,
base-4.8.2.0, base-4.8.1.0, base-4.8.0.0, base-4.7.0.2, base-4.7.0.1,
base-4.7.0.0, base-4.6.0.1, base-4.6.0.0, base-4.5.1.0, base-4.5.0.0,
base-4.4.1.0, base-4.4.0.0, base-4.3.1.0, base-4.3.0.0, base-4.2.0.2,
base-4.2.0.1, base-4.2.0.0, base-4.1.0.0, base-4.0.0.0, base-3.0.3.2,
base-3.0.3.1 (constraint from non-upgradeable package requires installed
instance)
[__4] fail (backjumping, conflict set: base, gloss-examples, repa)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: base, gloss-examples, gloss,
containers, repa
Try running with --minimize-conflict-set to improve the error message.
```